### PR TITLE
fixed load_json

### DIFF
--- a/src/HttpLibrary/__init__.py
+++ b/src/HttpLibrary/__init__.py
@@ -14,6 +14,8 @@ def load_json(json_string):
     try:
         return json.loads(json_string)
     except ValueError, e:
+        if isinstance(json_string, basestring):
+            return json_string
         raise ValueError("Could not parse '%s' as JSON: %s" % (json_string, e))
 
 

--- a/src/HttpLibrary/__init__.py
+++ b/src/HttpLibrary/__init__.py
@@ -14,8 +14,6 @@ def load_json(json_string):
     try:
         return json.loads(json_string)
     except ValueError, e:
-        if isinstance(json_string, basestring):
-            return json_string
         raise ValueError("Could not parse '%s' as JSON: %s" % (json_string, e))
 
 
@@ -623,10 +621,18 @@ class HTTP:
         | ${result}=       | Set Json Value | {"foo": {"bar": [1,2,3]}} | /foo | 12 |
         | Should Be Equal  | ${result}      | {"foo": 12}               |      |    |
         """
+        try:
+            loaded_json = load_json(json_value)
+        except ValueError, e:
+            if isinstance(json_value, basestring):
+                loaded_json = json_value
+            else:
+                raise ValueError("Could not parse '%s' as JSON: %s" % (json_value, e))
+
         return jsonpatch.apply_patch(json_string, [{
                                                    'op': 'add',
                                                    'path': json_pointer,
-                                                   'value': load_json(json_value)
+                                                   'value': loaded_json
                                                    }])
 
     @_with_json


### PR DESCRIPTION
“Set Json Value” Keyword always fails when supplied a string that is not “true” or “false” because json.dumps() in load_json cannot encode str to json. 

if json.dumps() loads an error, then just return json_string. 

Test Case

```
Set Json Value     {}    /testing   true  # always worked since json.dumps(‘true’) is valid 
Set Json Value   {}   /testing2   some_str   # was failing because json.dumps(‘some_str’) throws an error
```
